### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/client/main.js
+++ b/src/client/main.js
@@ -219,6 +219,17 @@
     const prevBtn = document.getElementById('prev-btn'); const nextBtn = document.getElementById('next-btn');
     let filterStatus = document.createElement('div'); filterStatus.className = 'filter-status'; filterStatus.style.display = 'none'; section.insertBefore(filterStatus, section.querySelector('.posts-grid'));
 
+    // Escape HTML for safe insertion
+    function escapeHTML(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/\//g, '&#x2F;');
+    }
+
     function getFilteredPosts() {
       if (activeTags.length === 0) return allPosts;
       return allPosts.filter(post => {
@@ -247,7 +258,7 @@
     }
     function updateFilterStatus() {
       if (activeTags.length === 0) { filterStatus.style.display = 'none'; return; }
-      const filteredCount = getFilteredPosts().length; const tagsDisplay = activeTags.map(tag => `<span class="filter-tag clickable-filter-tag" data-tag="${tag}">#${tag}</span>`).join(' ');
+      const filteredCount = getFilteredPosts().length; const tagsDisplay = activeTags.map(tag => `<span class="filter-tag clickable-filter-tag" data-tag="${escapeHTML(tag)}">#${escapeHTML(tag)}</span>`).join(' ');
       filterStatus.innerHTML = `<div class="filter-info"><span class="filter-prompt">$</span><span>grep --tag</span>${tagsDisplay}<span class="filter-count">→ ${filteredCount} result${filteredCount !== 1 ? 's' : ''}</span><button class="clear-filter" data-clear>clear</button></div>`;
       filterStatus.style.display = 'block';
       filterStatus.querySelector('[data-clear]')?.addEventListener('click', () => { activeTags = []; currentPage = 1; document.querySelectorAll('.tag').forEach(t => t.classList.remove('active')); updateFilterStatus(); updatePagination(); });


### PR DESCRIPTION
Potential fix for [https://github.com/rbstp/gist-blog/security/code-scanning/2](https://github.com/rbstp/gist-blog/security/code-scanning/2)

To prevent XSS, all untrusted data inserted into HTML via `.innerHTML` must be escaped for HTML meta-characters. Specifically, every `tag` value included in the template string must be escaped. The safest and most targeted remedy is to create a small utility function for HTML escaping (e.g., replacing `<`, `>`, `&`, `"`, `'`, `/` with appropriate entities). Use this escape function when constructing the `tagsDisplay` string (on line 250), so all tag values are properly encoded.

**Steps:**
- Add a helper function to escape HTML-unsafe characters.
- In the `tagsDisplay` construction (`activeTags.map(...)`), replace direct template interpolation with one that calls the escape function on `tag`, both for the `data-tag` attribute and its display value.
- The rest of the HTML string can remain unchanged, as its structure does not reinsert untrusted content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
